### PR TITLE
mail-bulkの削除

### DIFF
--- a/themes/histudy/_config.yml
+++ b/themes/histudy/_config.yml
@@ -22,7 +22,6 @@ customize:
         slack: https://join.slack.com/t/histudy/shared_invite/enQtNDgyMzQ0MTUxNjAyLWM4ZmE3MDNmMWU1OTY4OGU5YzNhZDU3YWE5NGM3NWFkNjA3ZTc5MDZmZmY5NTg4M2M4Y2EyZDA0YmM1NDVjZmE
         facebook: https://www.facebook.com/groups/301986313162703/
         github: https://github.com/histudy/
-        mail-bulk: https://groups.google.com/forum/?fromgroups#!forum/histudy
         rss: /atom.xml
 
 # Widgets


### PR DESCRIPTION
サイドメニューのリンクアイコンのうち、Mail-bulkが表示できていないので、削除しました。